### PR TITLE
Support for 'clean exit' to leave persistent pool, tests cleanup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ class PyTest(TestCommand):
         import pytest
         import sys
         import os
-        errcode = pytest.main(['--doctest-module', '-s', './shepherd', '--cov', 'shepherd', '-v', 'test/'])
+        errcode = pytest.main(['--doctest-module', './shepherd', '--cov', 'shepherd', '-v', 'test/'])
         sys.exit(errcode)
 
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ class PyTest(TestCommand):
         import pytest
         import sys
         import os
-        errcode = pytest.main(['--doctest-module', './shepherd', '--cov', 'shepherd', '-v', 'test/'])
+        errcode = pytest.main(['--doctest-module', '-s', './shepherd', '--cov', 'shepherd', '-v', 'test/'])
         sys.exit(errcode)
 
 

--- a/shepherd/pool.py
+++ b/shepherd/pool.py
@@ -201,7 +201,7 @@ class FixedSizePool(LaunchAllPool):
 
         pos = self.get_queue_pos(reqid)
         if pos >= 0:
-            return {'queued': pos}
+            return {'queue': pos}
 
         res = super(FixedSizePool, self).start(reqid, environ=environ)
 
@@ -320,13 +320,13 @@ class PersistentPool(LaunchAllPool):
                                                      pausable=self.stop_on_pause)
 
         elif self.redis.sismember(self.pool_wait_set, reqid):
-            return {'queued': self._find_wait_pos(reqid)}
+            return {'queue': self._find_wait_pos(reqid)}
 
         self._add_persist(reqid)
 
         if self.num_avail() == 0:
             pos = self._push_wait(reqid)
-            return {'queued': pos - 1}
+            return {'queue': pos - 1}
 
         return super(PersistentPool, self).start(reqid, environ=environ,
                                                  pausable=self.stop_on_pause)

--- a/shepherd/pool.py
+++ b/shepherd/pool.py
@@ -299,6 +299,18 @@ class PersistentPool(LaunchAllPool):
 
         self.stop_on_pause = kwargs.get('stop_on_pause', False)
 
+    def handle_die_event(self, reqid, event):
+        super(PersistentPool, self).handle_die_event(reqid, event)
+
+        attrs = event['Actor']['Attributes']
+
+        print(attrs)
+
+        # if 'clean exit', then stop entire flock, don't reschedule
+        if attrs['exitCode'] == '0' and attrs.get(self.shepherd.SHEP_DEFERRED_LABEL) != '1':
+            print('Persistent Flock Fully Finished: ' + reqid)
+            self.stop(reqid)
+
     def num_avail(self):
         max_size = self.redis.hget(self.pool_key, 'max_size')
         return int(max_size) - self.curr_size()

--- a/shepherd/pool.py
+++ b/shepherd/pool.py
@@ -185,7 +185,7 @@ class FixedSizePool(LaunchAllPool):
         self.reqid_to_number = self.REQID_TO_NUMBER.format(id=self.name)
         self.number_to_reqid = self.NUMBER_TO_REQID.format(id=self.name)
 
-        self.number_ttl = kwargs.get('number_ttl', self.NUMBER_TTL)
+        self.number_ttl = int(kwargs.get('number_ttl', self.NUMBER_TTL))
 
     def request(self, flock_name, req_opts):
         res = super(FixedSizePool, self).request(flock_name, req_opts)

--- a/shepherd/schema.py
+++ b/shepherd/schema.py
@@ -52,7 +52,7 @@ class LaunchContainerSchema(Schema):
 
 class LaunchResponseSchema(Schema):
     reqid = fields.String()
-    queued = fields.Int()
+    queue = fields.Int()
     network = fields.String()
     containers = fields.Dict(keys=fields.String(), values=fields.Nested(LaunchContainerSchema))
 

--- a/shepherd/shepherd.py
+++ b/shepherd/shepherd.py
@@ -23,6 +23,8 @@ class Shepherd(object):
 
     SHEP_REQID_LABEL = 'owt.shepherd.reqid'
 
+    SHEP_DEFERRED_LABEL = 'owt.shepherd.deferred'
+
     DEFAULT_REQ_TTL = 120
 
     UNTRACKED_CHECK_TIME = 30
@@ -246,6 +248,7 @@ class Shepherd(object):
         try:
             labels = labels or {}
             labels[self.reqid_label] = flock_req.reqid
+            labels[self.SHEP_DEFERRED_LABEL] = '1'
 
             spec = self.find_spec_for_flock_req(flock_req, image_name)
 

--- a/shepherd/shepherd.py
+++ b/shepherd/shepherd.py
@@ -506,7 +506,9 @@ class Shepherd(object):
         return volume_binds, volumes_list
 
     def get_flock_containers(self, flock_req):
-        return self.docker.containers.list(all=True, filters={'label': self.reqid_label + '=' + flock_req.reqid})
+        return self.docker.containers.list(all=True,
+                                           filters={'label': self.reqid_label + '=' + flock_req.reqid},
+                                           ignore_removed=True) or []
 
     def remove_flock_volumes(self, flock_req):
         num_volumes = flock_req.data.get('num_volumes', 0)
@@ -582,7 +584,9 @@ class Shepherd(object):
 
         while True:
             try:
-                all_containers = self.docker.containers.list(all=False, filters=filters)
+                all_containers = self.docker.containers.list(all=False,
+                                                             filters=filters,
+                                                             ignore_removed=True)
 
                 reqids = set()
                 network_names = set()

--- a/shepherd/shepherd.py
+++ b/shepherd/shepherd.py
@@ -597,10 +597,12 @@ class Shepherd(object):
                     if self.is_valid_flock(reqid):
                         continue
 
+                    print('Invalid Flock: ' + reqid)
+
                     reqids.add(reqid)
 
                     short_id = self._remove_container(container)
-                    print('Removed untracked container: ' + str(short_id))
+                    print('Removed untracked container from flock {0}: {1}'.format(reqid, short_id))
 
                 # remove volumes + reqid
                 for reqid in reqids:

--- a/shepherd/shepherd.py
+++ b/shepherd/shepherd.py
@@ -47,9 +47,20 @@ class Shepherd(object):
 
         self.reqid_label = reqid_label or self.SHEP_REQID_LABEL
 
-        self.untracked_check_time = untracked_check_time or self.UNTRACKED_CHECK_TIME
+        self.untracked_check_time = 0
+        self.start_cleanup_loop(untracked_check_time)
 
+    def start_cleanup_loop(self, untracked_check_time):
         if self.untracked_check_time > 0:
+            # already started
+            return
+
+        if untracked_check_time is None:
+            untracked_check_time = self.UNTRACKED_CHECK_TIME
+
+        self.untracked_check_time = untracked_check_time
+
+        if untracked_check_time > 0:
             gevent.spawn(self.untracked_check_loop)
 
     def load_flocks(self, flocks_file_or_dir):
@@ -584,7 +595,7 @@ class Shepherd(object):
 
         filters = {'label': self.reqid_label}
 
-        while True:
+        while self.untracked_check_time > 0:
             try:
                 all_containers = self.docker.containers.list(all=False,
                                                              filters=filters,

--- a/shepherd/shepherd.py
+++ b/shepherd/shepherd.py
@@ -415,11 +415,6 @@ class Shepherd(object):
         if not flock_req.load(self.redis):
             return {'error': 'invalid_reqid'}
 
-        if not keep_reqid:
-            flock_req.delete(self.redis)
-        else:
-            flock_req.stop(self.redis)
-
         try:
             network = self.get_network(flock_req)
         except:
@@ -458,6 +453,13 @@ class Shepherd(object):
             self.remove_flock_volumes(flock_req)
         except:
             pass
+
+        # delete flock after docker removal is finished to avoid race condition
+        # with 'untracked' container removal
+        if not keep_reqid:
+            flock_req.delete(self.redis)
+        else:
+            flock_req.stop(self.redis)
 
         return {'success': True}
 

--- a/shepherd/wsgi.py
+++ b/shepherd/wsgi.py
@@ -50,6 +50,8 @@ class Validator():
             return self.make_response({'error': 'no_such_pool', 'pool': str(ns)}, 400)
 
         except Exception as e:
+            import traceback
+            traceback.print_exc()
             return self.make_response({'error': str(e)}, 400)
 
         if self.resp_schema:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -76,7 +76,7 @@ def shepherd(redis):
                     reqid_label=TEST_REQID_LABEL,
                     network_templ=NETWORKS_NAME,
                     network_label=TEST_NETWORK_LABEL,
-                    untracked_check_time=2.0)
+                    untracked_check_time=0)
 
     shep.load_flocks(TEST_FLOCKS)
     return shep

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -7,6 +7,7 @@ import fakeredis
 import os
 import docker
 import glob
+import gevent.lock
 
 
 NETWORKS_NAME = 'test-shepherd.net:{0}'
@@ -26,30 +27,34 @@ class DebugMixin(object):
         super(DebugMixin, self).__init__(*args, **kwargs)
         self.start_events = []
         self.stop_events = []
+        self._lock = gevent.lock.Semaphore()
 
         self.reqid_starts = {}
         self.reqid_stops = {}
 
-    def handle_die_event(self, reqid, event):
-        super(DebugMixin, self).handle_die_event(reqid, event)
+    def handle_die_event(self, reqid, event, attrs):
         self.stop_events.append(event)
 
         try:
-            reqid = event['Actor']['Attributes'][TEST_REQID_LABEL]
-            self.reqid_stops[reqid] = self.reqid_stops.get(reqid, 0) + 1
+            reqid = attrs[TEST_REQID_LABEL]
+            with self._lock:
+                self.reqid_stops[reqid] = self.reqid_stops.get(reqid, 0) + 1
         except:
             pass
 
-    def handle_start_event(self, reqid, event):
-        super(DebugMixin, self).handle_start_event(reqid, event)
+        super(DebugMixin, self).handle_die_event(reqid, event, attrs)
+
+    def handle_start_event(self, reqid, event, attrs):
         self.start_events.append(event)
 
         try:
-            reqid = event['Actor']['Attributes'][TEST_REQID_LABEL]
-            self.reqid_starts[reqid] = self.reqid_starts.get(reqid, 0) + 1
+            reqid = attrs[TEST_REQID_LABEL]
+            with self._lock:
+                self.reqid_starts[reqid] = self.reqid_starts.get(reqid, 0) + 1
         except:
             pass
 
+        super(DebugMixin, self).handle_start_event(reqid, event, attrs)
 
 class DebugLaunchAllPool(DebugMixin, LaunchAllPool):
     pass

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -133,13 +133,13 @@ def app(shepherd, pool):
 def docker_client():
     docker_cli = docker.from_env()
 
-    for filename in glob.glob(os.path.join(TEST_DIR, 'Dockerfile.*')):
+    for filename in sorted(glob.glob(os.path.join(TEST_DIR, 'Dockerfile.*'))):
         path, dockerfile = os.path.split(filename)
         name = dockerfile.rsplit('.', 1)[1]
         docker_cli.images.build(path=path,
-                                   dockerfile=dockerfile,
-                                   tag='test-shepherd/' + name,
-                                   rm=True)
+                                dockerfile=dockerfile,
+                                tag='test-shepherd/' + name,
+                                rm=True)
 
     yield docker_cli
 

--- a/test/data/Dockerfile.exit0
+++ b/test/data/Dockerfile.exit0
@@ -1,0 +1,5 @@
+FROM test-shepherd/busybox
+
+ENV FOO EXIT
+CMD sh -c 'exit 0'
+

--- a/test/test_01_basic_api.py
+++ b/test/test_01_basic_api.py
@@ -1,6 +1,6 @@
 from gevent.monkey import patch_all; patch_all()
 import pytest
-import time
+from utils import sleep_try
 
 
 # ============================================================================
@@ -56,8 +56,11 @@ class TestBasicApi:
         assert res.json['containers']['box']['environ']['NEW'] == 'VALUE'
         assert res.json['network']
 
-        time.sleep(0.2)
-        assert len(pool.start_events) == 2
+        def assert_done():
+            assert len(pool.start_events) == 2
+
+        sleep_try(0.2, 6.0, assert_done)
+
         for event in pool.start_events:
             assert event['Action'] == 'start'
             assert event['Actor']['Attributes'][pool.shepherd.reqid_label] == self.reqid
@@ -69,8 +72,11 @@ class TestBasicApi:
         res = self.client.post('/api/stop_flock/' + self.reqid)
         assert res.json['success'] == True
 
-        time.sleep(0.2)
-        assert len(pool.stop_events) == 2
+        def assert_done():
+            assert len(pool.stop_events) == 2
+
+        sleep_try(0.2, 6.0, assert_done)
+
         for event in pool.stop_events:
             assert event['Action'] == 'die'
             assert event['Actor']['Attributes'][pool.shepherd.reqid_label] == self.reqid

--- a/test/test_01_deferred_api.py
+++ b/test/test_01_deferred_api.py
@@ -1,7 +1,5 @@
 from gevent.monkey import patch_all; patch_all()
 import pytest
-import time
-import itertools
 
 from shepherd.wsgi import create_app
 

--- a/test/test_04_fixed_pool_api.py
+++ b/test/test_04_fixed_pool_api.py
@@ -41,6 +41,7 @@ class TestFixedPoolApi:
     def do_req_and_start(self, **params):
         res = self.do_req(params)
         if 'error' in res:
+            print(res)
             return res, None
 
         reqid = res['reqid']

--- a/test/test_04_fixed_pool_api.py
+++ b/test/test_04_fixed_pool_api.py
@@ -38,7 +38,7 @@ class TestFixedPoolApi:
     def do_req_and_start(self, **params):
         res = self.do_req(params)
         if 'error' in res:
-            return res
+            return res, None
 
         reqid = res['reqid']
         res = self.client.post('/api/start_flock/' + reqid)

--- a/test/test_04_fixed_pool_api.py
+++ b/test/test_04_fixed_pool_api.py
@@ -41,7 +41,6 @@ class TestFixedPoolApi:
     def do_req_and_start(self, **params):
         res = self.do_req(params)
         if 'error' in res:
-            print(res)
             return res, None
 
         reqid = res['reqid']

--- a/test/test_04_fixed_pool_api.py
+++ b/test/test_04_fixed_pool_api.py
@@ -75,7 +75,7 @@ class TestFixedPoolApi:
     def test_pool_full_request(self, redis):
         for x in range(0, 10):
             res, reqid = self.queue_req()
-            assert res['queued'] == x
+            assert res['queue'] == x
 
     def test_expire_queue_next_in_order(self, redis, docker_client):
         self.remove_next(docker_client)
@@ -86,14 +86,14 @@ class TestFixedPoolApi:
         self.sleep_try(0.2, 6.0, assert_done)
 
         res = self.client.post('/api/start_flock/' + self.pending[1])
-        assert res.json['queued'] == 1
+        assert res.json['queue'] == 1
 
         res = self.client.post('/api/start_flock/' + self.pending[0])
         assert res.json['containers']['box']
         self.ids.append(res.json['containers']['box']['id'])
 
         res = self.client.post('/api/start_flock/' + self.pending[1])
-        assert res.json['queued'] == 0
+        assert res.json['queue'] == 0
 
     def test_expire_queue_next_out_of_order(self, redis, docker_client):
         self.remove_next(docker_client)
@@ -105,29 +105,29 @@ class TestFixedPoolApi:
         self.sleep_try(0.2, 6.0, assert_done)
 
         res = self.start(self.pending[4])
-        assert res['queued'] == 3
+        assert res['queue'] == 3
 
         res = self.start(self.pending[2])
         assert res['containers']
 
         res = self.start(self.pending[4])
-        assert res['queued'] == 3
+        assert res['queue'] == 3
 
         res = self.start(self.pending[1])
         assert res['containers']
 
         res = self.start(self.pending[4])
-        assert res['queued'] == 1
+        assert res['queue'] == 1
 
         res = self.start(self.pending[3])
-        assert res['queued'] == 0
+        assert res['queue'] == 0
 
     def test_expire_unused(self, redis, fixed_pool):
         res = self.start(self.pending[6])
-        assert res['queued'] == 3
+        assert res['queue'] == 3
 
         res, reqid = self.queue_req()
-        assert res['queued'] == 7
+        assert res['queue'] == 7
 
         # simulate expiry
         fixed_pool.remove_request(self.pending[3])
@@ -136,14 +136,14 @@ class TestFixedPoolApi:
         fixed_pool.remove_request(self.pending[6])
 
         res = self.start(reqid)
-        assert res['queued'] == 3
+        assert res['queue'] == 3
 
         res = self.start(self.pending[7])
-        assert res['queued'] == 0
+        assert res['queue'] == 0
 
         res = self.start(self.pending[6])
-        assert res['queued'] == 4
+        assert res['queue'] == 4
 
         res = self.start(self.pending[3])
-        assert res['queued'] == 5
+        assert res['queue'] == 5
 

--- a/test/test_04_fixed_pool_api.py
+++ b/test/test_04_fixed_pool_api.py
@@ -18,7 +18,10 @@ class TestFixedPoolApi:
 
     def remove_next(self, docker_client):
         cid = self.ids.pop()
-        docker_client.containers.get(cid).kill()
+        try:
+            docker_client.containers.get(cid).kill()
+        except:
+            pass
 
     def start(self, reqid):
         res = self.client.post('/api/start_flock/' + reqid)

--- a/test/test_05_persist_pool_api.py
+++ b/test/test_05_persist_pool_api.py
@@ -157,5 +157,5 @@ class TestPersistPoolApi:
 
             assert persist_pool.reqid_starts == persist_pool.reqid_stops
 
-        sleep_try(0.2, 25.0, assert_done)
+        sleep_try(0.2, 35.0, assert_done)
 

--- a/test/test_05_persist_pool_api.py
+++ b/test/test_05_persist_pool_api.py
@@ -146,7 +146,7 @@ class TestPersistPoolApi:
         while len(self.reqids) > 0:
             remove = self.reqids.pop()
             self.stop(remove)
-            time.sleep(0.2)
+            #time.sleep(0.2)
 
         def assert_done():
             assert redis.scard('p:persist-pool:f') == 0
@@ -157,5 +157,5 @@ class TestPersistPoolApi:
 
             assert persist_pool.reqid_starts == persist_pool.reqid_stops
 
-        sleep_try(0.2, 20.0, assert_done)
+        sleep_try(0.2, 25.0, assert_done)
 

--- a/test/test_05_persist_pool_api.py
+++ b/test/test_05_persist_pool_api.py
@@ -110,7 +110,7 @@ class TestPersistPoolApi:
 
         for x in range(1, 4):
             res, reqid = self.do_req_and_start()
-            assert res['queued'] == x - 1
+            assert res['queue'] == x - 1
             assert redis.scard('p:persist-pool:f') == 3
 
             assert redis.llen('p:persist-pool:q') == x
@@ -118,7 +118,7 @@ class TestPersistPoolApi:
 
             # ensure double start doesn't move position
             res = self.client.post('/api/persist-pool/start_flock/' + reqid)
-            assert res.json['queued'] == x - 1
+            assert res.json['queue'] == x - 1
 
         for x in range(1, 10):
             time.sleep(2.1)

--- a/test/test_06_cleanup.py
+++ b/test/test_06_cleanup.py
@@ -10,7 +10,7 @@ from utils import sleep_try
 @pytest.mark.usefixtures('client_class', 'docker_client')
 class TestCleanup(object):
     def _count_containers(self, docker_client, shepherd):
-        return len(docker_client.containers.list(filters={'label': shepherd.reqid_label}))
+        return len(docker_client.containers.list(filters={'label': shepherd.reqid_label}, ignore_removed=True))
 
     def _count_volumes(self, docker_client, shepherd):
         return len(docker_client.volumes.list(filters={'label': shepherd.reqid_label}))

--- a/test/test_06_cleanup.py
+++ b/test/test_06_cleanup.py
@@ -7,7 +7,7 @@ from shepherd.wsgi import create_app
 from utils import sleep_try
 
 
-@pytest.mark.usefixtures('client_class', 'docker_client')
+@pytest.mark.usefixtures('client_class', 'docker_client', 'shepherd')
 class TestCleanup(object):
     def _count_containers(self, docker_client, shepherd):
         return len(docker_client.containers.list(filters={'label': shepherd.reqid_label}, ignore_removed=True))
@@ -17,6 +17,11 @@ class TestCleanup(object):
 
     def _count_networks(self, docker_client, shepherd):
         return len(docker_client.networks.list(filters={'label': shepherd.network_pool.network_label}))
+
+    def test_start_loop(self, shepherd):
+        assert shepherd.untracked_check_time == 0
+        shepherd.start_cleanup_loop(2.0)
+        assert shepherd.untracked_check_time == 2.0
 
     def test_ensure_flock_stop(self, docker_client):
         res = self.client.post('/api/request_flock/test_b')

--- a/test/test_06_cleanup.py
+++ b/test/test_06_cleanup.py
@@ -1,28 +1,14 @@
 from gevent.monkey import patch_all; patch_all()
 
 import pytest
-import time
-import itertools
 import docker
 
 from shepherd.wsgi import create_app
-
+from utils import sleep_try
 
 
 @pytest.mark.usefixtures('client_class', 'docker_client')
 class TestCleanup(object):
-    @classmethod
-    def sleep_try(cls, sleep_interval, max_time, test_func):
-        max_count = float(max_time) / sleep_interval
-        for counter in itertools.count():
-            try:
-                time.sleep(sleep_interval)
-                test_func()
-                return
-            except:
-                if counter >= max_count:
-                    raise
-
     def _count_containers(self, docker_client, shepherd):
         return len(docker_client.containers.list(filters={'label': shepherd.reqid_label}))
 
@@ -50,7 +36,7 @@ class TestCleanup(object):
             with pytest.raises(docker.errors.NotFound):
                 box = docker_client.containers.get(res.json['containers']['box-2']['id'])
 
-        self.sleep_try(0.3, 10.0, assert_removed)
+        sleep_try(0.3, 10.0, assert_removed)
 
     def test_check_untracked_cleanup(self, docker_client, redis, shepherd):
         num_containers = self._count_containers(docker_client, shepherd)
@@ -78,7 +64,7 @@ class TestCleanup(object):
             assert num_volumes == self._count_volumes(docker_client, shepherd)
             #assert num_networks == self._count_networks(docker_client, shepherd)
 
-        self.sleep_try(2.0, 20.0, assert_removed)
+        sleep_try(2.0, 20.0, assert_removed)
 
     def test_redis_pool_and_reqid_cleanup(self, docker_client, redis):
         reqids = []
@@ -109,4 +95,4 @@ class TestCleanup(object):
             assert len(redis.smembers('p:test-pool:f')) == 0
             assert redis.keys('*') == []
 
-        self.sleep_try(1.0, 10.0, assert_removed)
+        sleep_try(1.0, 10.0, assert_removed)

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,0 +1,15 @@
+import time
+import itertools
+
+def sleep_try(sleep_interval, max_time, test_func):
+    max_count = float(max_time) / sleep_interval
+    for counter in itertools.count():
+        try:
+            time.sleep(sleep_interval)
+            test_func()
+            return
+        except:
+            if counter >= max_count:
+                raise
+
+


### PR DESCRIPTION
- If container in persistent pool exits with 0, assume done and do not re-queue.
- When calling 'container.list', add ignore_removed
- Log stack trace for unexpected 400
- cleanup loop: can be started with start_cleanup_loop() explicitly
- stop flock: delete flock at end to avoid race condition with untracked container loop

Test improvements:
- add sleep_try() to shared utils
- better exception handling
- don't start untracked container cleanup until cleanup tests to avoid race condition